### PR TITLE
Revert "Build(deps): Bump github.com/labstack/echo/v4 from 4.1.6 to 4.1.10 in /server"

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/kr/pty v1.1.8 // indirect
-	github.com/labstack/echo/v4 v4.1.10
+	github.com/labstack/echo/v4 v4.1.6
 	github.com/labstack/gommon v0.3.0
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect


### PR DESCRIPTION
Reverts thecampagnards/docktor#263 It looks like we have some regressions, similar to labstack/echo#1356